### PR TITLE
release 1.1.0 -- modular libhalmplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ Open Fronthaul Interface specified by O-RAN Workgroup 4.
   the implementation in `fb-oru`.
 * **mplane_client** - M-Plane client implementation.
 * **climp** - A command-line interface utility for M-Plane operations.
-* **fb-oru** - Code for the operating system and applications of an O-RU. This
-  includes the legacy implementation of the M-Plane server, which has most of
-  its code contained in `fb-oru/yang-manager-server`.
+
+## Client and Server Configuration Workflow
+* Follow the [meta-mplane](https://github.com/lf-connectivity/open-mplane/tree/main/meta-mplane)
+  setup guide to build and run the mplane_server
+* Build the [mplane_client](https://github.com/lf-connectivity/open-mplane/tree/main/mplane_client)
+  on your host or using Docker
+* Use the [mpclient-demo](https://github.com/lf-connectivity/open-mplane/tree/main/mplane_client/example)
+  or the [M-Plane Demo](https://github.com/lf-connectivity/open-mplane/tree/main/mplane_client/example/demo)
+  to connect and communicate with the server
 
 ## License
 Open M-Plane is MIT licensed, as found in the LICENSE file.

--- a/libhalmplane/CMakeLists.txt
+++ b/libhalmplane/CMakeLists.txt
@@ -38,8 +38,8 @@ elseif( "${CONTEXT}" STREQUAL "YOCTO")
   endif()
 
   set(LIBRARY_NAME halmplane)
-  set(version "0.1")
-  project (halmplane VERSION 0.1.0 LANGUAGES CXX)
+  set(version "1.1")
+  project (halmplane VERSION 1.1.0 LANGUAGES CXX)
   add_library(${LIBRARY_NAME} SHARED)
   set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
   set_target_properties(${LIBRARY_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
@@ -54,10 +54,8 @@ elseif( "${CONTEXT}" STREQUAL "YOCTO")
   endif()
 
   if (NOT GITDIR)
-
     get_filename_component (GITDIR ${PROJECT_SOURCE_DIR} DIRECTORY)
     list(APPEND CMAKE_MODULE_PATH ${GITDIR}/buildTools/cmake/Modules)
-
   endif()
 
   include_directories(
@@ -69,8 +67,12 @@ elseif( "${CONTEXT}" STREQUAL "YOCTO")
   include(${BOARD}/CMakeLists.txt)
   target_include_directories(halmplane PUBLIC hal-common/inc)
   target_include_directories(halmplane PUBLIC inc)
-  install(
-    FILES
+
+  if(${BUILD_BOARD_STYLE} STREQUAL "MODULE")
+    set_target_properties(${LIBRARY_NAME} PROPERTIES OUTPUT_NAME ${LIBRARY_NAME}-mod-${BOARD})
+  else()
+    install(
+      FILES
       inc/MplaneAlarms.h
       inc/MplaneAntennaCalibration.h
       inc/MplaneBeamforming.h
@@ -92,59 +94,9 @@ elseif( "${CONTEXT}" STREQUAL "YOCTO")
       inc/MplaneFan.h
       inc/MplaneSync.h
       inc/HalMplane.h
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  )
-
-  install(TARGETS halmplane
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  )
-elseif( "${CONTEXT}" STREQUAL "MODULE")
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-
-  if (ASAN)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -fsanitize=address")
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
   endif()
-
-  set(version "1.1")
-  set(LIBRARY_NAME halmplane)
-  project (halmplane VERSION 1.1.0 LANGUAGES CXX)
-  add_library(${LIBRARY_NAME} SHARED)
-  set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
-  set_target_properties(${LIBRARY_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
-
-  include(GNUInstallDirs)
-
-  # Build context
-  if(${BUILD_BOARD} STREQUAL "ZCU111")
-     set(BOARD "zcu111")
-     include_directories(
-       ${PROJECT_SOURCE_DIR}/../mplane_server/common/inc/
-     )
-  else()
-     set(BOARD "${BUILD_BOARD}")
-  endif()
-
-  set_target_properties(${LIBRARY_NAME} PROPERTIES OUTPUT_NAME ${LIBRARY_NAME}-mod-${BOARD})
-
-  if (NOT GITDIR)
-
-    get_filename_component (GITDIR ${PROJECT_SOURCE_DIR} DIRECTORY)
-    list(APPEND CMAKE_MODULE_PATH ${GITDIR}/buildTools/cmake/Modules)
-
-  endif()
-
-  include_directories(
-    ${PROJECT_SOURCE_DIR}/inc/
-    ${PROJECT_SOURCE_DIR}/hal-common/inc/
-  )
-
-  add_subdirectory(hal-common)
-  include(${BOARD}/CMakeLists.txt)
-  target_include_directories(halmplane PUBLIC hal-common/inc)
-  target_include_directories(halmplane PUBLIC inc)
 
   install(TARGETS halmplane
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/libhalmplane/CMakeLists.txt
+++ b/libhalmplane/CMakeLists.txt
@@ -98,6 +98,57 @@ elseif( "${CONTEXT}" STREQUAL "YOCTO")
   install(TARGETS halmplane
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
+elseif( "${CONTEXT}" STREQUAL "MODULE")
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
+  if (ASAN)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -fsanitize=address")
+  endif()
+
+  set(version "1.1")
+  set(LIBRARY_NAME halmplane)
+  project (halmplane VERSION 1.1.0 LANGUAGES CXX)
+  add_library(${LIBRARY_NAME} SHARED)
+  set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
+  set_target_properties(${LIBRARY_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
+
+  include(GNUInstallDirs)
+
+  # Build context
+  if(${BUILD_BOARD} STREQUAL "ZCU111")
+     set(BOARD "zcu111")
+     include_directories(
+       ${PROJECT_SOURCE_DIR}/../mplane_server/common/inc/
+     )
+  else()
+     set(BOARD "${BUILD_BOARD}")
+  endif()
+
+  set_target_properties(${LIBRARY_NAME} PROPERTIES OUTPUT_NAME ${LIBRARY_NAME}-mod-${BOARD})
+
+  if (NOT GITDIR)
+
+    get_filename_component (GITDIR ${PROJECT_SOURCE_DIR} DIRECTORY)
+    list(APPEND CMAKE_MODULE_PATH ${GITDIR}/buildTools/cmake/Modules)
+
+  endif()
+
+  include_directories(
+    ${PROJECT_SOURCE_DIR}/inc/
+    ${PROJECT_SOURCE_DIR}/hal-common/inc/
+  )
+
+  add_subdirectory(hal-common)
+  include(${BOARD}/CMakeLists.txt)
+  target_include_directories(halmplane PUBLIC hal-common/inc)
+  target_include_directories(halmplane PUBLIC inc)
+
+  install(TARGETS halmplane
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
 
 else() # fb-oru app build
   set(version "0.1")

--- a/libhalmplane/README.md
+++ b/libhalmplane/README.md
@@ -27,3 +27,5 @@ shared library is generated and may be installed on a host system with the
 `make install/$TARGET` Makefile target.
 
 *libhalmplane* is also incorporated into the `yang-manager-server` build.
+
+See `modular/README.md` for a detailed explanation of using the `modular` board type.

--- a/libhalmplane/example/CMakeLists.txt
+++ b/libhalmplane/example/CMakeLists.txt
@@ -6,9 +6,5 @@ string(CONCAT SRC
 )
 include_directories(inc)
 
-if(("${CONTEXT}" STREQUAL "YOCTO") OR ("${CONTEXT}" STREQUAL "MODULE"))
-  list(TRANSFORM SRC PREPEND "example/")
-  target_sources(halmplane PRIVATE ${SRC})
-else()
-  add_sources(SOURCES ${SRC})
-endif()
+list(TRANSFORM SRC PREPEND "example/")
+target_sources(halmplane PRIVATE ${SRC})

--- a/libhalmplane/example/CMakeLists.txt
+++ b/libhalmplane/example/CMakeLists.txt
@@ -6,7 +6,7 @@ string(CONCAT SRC
 )
 include_directories(inc)
 
-if( "${CONTEXT}" STREQUAL "YOCTO")
+if(("${CONTEXT}" STREQUAL "YOCTO") OR ("${CONTEXT}" STREQUAL "MODULE"))
   list(TRANSFORM SRC PREPEND "example/")
   target_sources(halmplane PRIVATE ${SRC})
 else()

--- a/libhalmplane/example/src/HalMplane.cpp
+++ b/libhalmplane/example/src/HalMplane.cpp
@@ -14,14 +14,9 @@
 
 using namespace tinyxml2;
 
-int halmplane_init()
+int halmplane_init(tinyxml2::XMLDocument* doc)
 {
     return 0;
-}
-
-int halmplane_config(tinyxml2::XMLDocument* doc)
-{
-  return 0;
 }
 
 int halmplane_exit()
@@ -37,10 +32,8 @@ typedef struct
 
 static labeled_ptr_t api_functions[] = {
   // HalMplane.h
-  {"int halmplane_init()",
-   (void*)(int (*)()) halmplane_init},
-  {"int halmplane_config(XMLDocument*)",
-   (void*)(int (*)(XMLDocument*)) halmplane_config},
+  {"int halmplane_init(XMLDocument*)",
+   (void*)(int (*)(XMLDocument*)) halmplane_init},
   {"int halmplane_exit()",
    (void*)(int (*)()) halmplane_exit},
 

--- a/libhalmplane/example/src/HalMplane.cpp
+++ b/libhalmplane/example/src/HalMplane.cpp
@@ -5,14 +5,106 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <map>
+#include "libtinyxml2/tinyxml2.h"
 #include "HalMplane.h"
+#include "MplaneInterfaces.h"
+#include "MplaneProcessingElements.h"
+#include "MplaneUplaneConf.h"
+
+using namespace tinyxml2;
 
 int halmplane_init()
 {
     return 0;
 }
 
+int halmplane_config(tinyxml2::XMLDocument* doc)
+{
+  return 0;
+}
+
 int halmplane_exit()
 {
     return 0;
+}
+
+typedef struct
+{
+  const char* key;
+  void* ptr;
+} labeled_ptr_t;
+
+static labeled_ptr_t api_functions[] = {
+  // HalMplane.h
+  {"int halmplane_init()",
+   (void*)(int (*)()) halmplane_init},
+  {"int halmplane_config(XMLDocument*)",
+   (void*)(int (*)(XMLDocument*)) halmplane_config},
+  {"int halmplane_exit()",
+   (void*)(int (*)()) halmplane_exit},
+
+  // MplaneInterfaces.h
+  {"halmplane_error_t halmplane_interface_update(interface_t*)",
+   (void*)(halmplane_error_t (*)(interface_t*)) halmplane_interface_update},
+  {"halmplane_error_t halmplane_interface_update_description(const char*, const char*)",
+   (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_description},
+  {"halmplane_error_t halmplane_interface_update_type(const char*, const char*)",
+   (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_type},
+  {"halmplane_error_t halmplane_interface_update_enabled(const char*, bool)",
+   (void*)(halmplane_error_t (*)(const char*, bool)) halmplane_interface_update_enabled},
+  {"halmplane_error_t halmplane_interface_update_l2_mtu(const char*, int)",
+   (void*)(halmplane_error_t (*)(const char*, int)) halmplane_interface_update_l2_mtu},
+  {"halmplane_error_t halmplane_interface_update_vlan_tagging(const char*, bool)",
+   (void*)(halmplane_error_t (*)(const char*, bool)) halmplane_interface_update_vlan_tagging},
+  {"halmplane_error_t halmplane_interface_update_base_interface(const char*, const char*)",
+   (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_base_interface},
+  {"halmplane_error_t halmplane_interface_update_vlan_id(const char*, int)",
+   (void*)(halmplane_error_t (*)(const char*, int)) halmplane_interface_update_vlan_id},
+  {"halmplane_error_t halmplane_interface_update_mac_address(const char*, const char*)",
+   (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_mac_address},
+
+  // MplaneProcessingElements.h
+  {"halmplane_error_t halmplane_update_ru_element(ru_elements_t*)",
+   (void*)(halmplane_error_t (*)(ru_elements_t*)) halmplane_update_ru_element},
+
+  // MplaneUplaneConf.h
+  {"int halmplane_setUPlaneConfiguration(user_plane_configuration_t*)",
+   (void*)(int (*)(user_plane_configuration_t*)) halmplane_setUPlaneConfiguration},
+  {"int halmplane_update_rx_eaxc(const char*, e_axcid_t*)",
+   (void*)(int (*)(const char*, e_axcid_t*)) halmplane_update_rx_eaxc},
+  {"int halmplane_update_tx_eaxc(const char*, e_axcid_t*)",
+   (void*)(int (*)(const char*, e_axcid_t*)) halmplane_update_tx_eaxc},
+  {"int halmplane_update_rx_endpoint_compression(const char*, compression_t*)",
+   (void*)(int (*)(const char*, compression_t*)) halmplane_update_rx_endpoint_compression},
+  {"int halmplane_update_tx_endpoint_compression(const char*, compression_t*)",
+   (void*) (int (*)(const char*, compression_t*)) halmplane_update_tx_endpoint_compression},
+  {"int halmplane_update_rx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)",
+   (void*)(int (*)(const char*, dynamic_compression_configuration_t*)) halmplane_update_rx_endpoint_compression_dyn_config},
+  {"int halmplane_update_tx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)",
+   (void*) (int (*)(const char*, dynamic_compression_configuration_t*)) halmplane_update_tx_endpoint_compression_dyn_config},
+  {"int halmplane_register_rx_carrier_state_cb(halmplane_carrier_state_cb_t)",
+   (void*)(int (*)(halmplane_carrier_state_cb_t)) halmplane_register_rx_carrier_state_cb},
+  {"int halmplane_register_tx_carrier_state_cb(halmplane_carrier_state_cb_t)",
+   (void*)(int (*)(halmplane_carrier_state_cb_t)) halmplane_register_tx_carrier_state_cb},
+
+  {NULL, NULL}
+};
+
+
+extern "C"
+{
+  void *function_map()
+  {
+    std::map<std::string, void*> *registered_functions;
+    registered_functions = new std::map<std::string, void*>();
+
+    int i = 0;
+    while(api_functions[i].key != NULL)
+      {
+	(*registered_functions)[api_functions[i].key] = api_functions[i].ptr;
+	i++;
+      }
+    return registered_functions;
+  }
 }

--- a/libhalmplane/hal-common/CMakeLists.txt
+++ b/libhalmplane/hal-common/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(inc)
 
-if( "${CONTEXT}" STREQUAL "YOCTO")
+if(("${CONTEXT}" STREQUAL "YOCTO") OR ("${CONTEXT}" STREQUAL "MODULE"))
   if( "${BOARD}" STREQUAL "zcu111")
     string(CONCAT SRC
       "hal-common/fb-oru/FbOruPerformanceMgmt.cpp;"

--- a/libhalmplane/inc/HalMplane.h
+++ b/libhalmplane/inc/HalMplane.h
@@ -12,16 +12,11 @@
 /**
  * @brief HAL init function, to be called before YANG handlers initialization.
  *
- * @return 0 if successful, 1 otherwise
- */
-int halmplane_init();
-
-/**
- * @brief HAL config function, to give HAL implementations a chance to look at server config during startup
+ * doc is a pointer to an xml config object if any board needs to preset runtime parameters
  *
  * @return 0 if successful, 1 otherwise
  */
-int halmplane_config(tinyxml2::XMLDocument* doc);
+int halmplane_init(tinyxml2::XMLDocument* doc);
 
 /**
  * @brief HAL exit function, to be called when application exits.

--- a/libhalmplane/inc/HalMplane.h
+++ b/libhalmplane/inc/HalMplane.h
@@ -7,16 +7,24 @@
 
 #ifndef __HAL_MPLANE_H__
 #define __HAL_MPLANE_H__
+#include "libtinyxml2/tinyxml2.h"
 
 /**
- * @brief HAl init function, to be called before YANG handlers initialization.
+ * @brief HAL init function, to be called before YANG handlers initialization.
  *
  * @return 0 if successful, 1 otherwise
  */
 int halmplane_init();
 
 /**
- * @brief HAl exit function, to be called when application exits.
+ * @brief HAL config function, to give HAL implementations a chance to look at server config during startup
+ *
+ * @return 0 if successful, 1 otherwise
+ */
+int halmplane_config(tinyxml2::XMLDocument* doc);
+
+/**
+ * @brief HAL exit function, to be called when application exits.
  *
  * @return 0 if successful, 1 otherwise
  */

--- a/libhalmplane/inc/MplaneAntennaCalibration.h
+++ b/libhalmplane/inc/MplaneAntennaCalibration.h
@@ -53,6 +53,6 @@ typedef struct antenna_calibration_data_s {
  * @ingroup AntennaCalibrationFunctions
  */
 halmplane_error_t halmplane_start_antenna_calibration(
-    const* antenna_calibration_data_t);
+    const antenna_calibration_data_t*);
 
 #endif // __MPLANE_ANTENNA_CALIBRATION_H__

--- a/libhalmplane/inc/MplaneFan.h
+++ b/libhalmplane/inc/MplaneFan.h
@@ -13,7 +13,7 @@
 #include <unistd.h>
 
 #include "MplaneTypes.h"
-#include "smbus.h"
+
 
 /** @struct fan_state_s
  * @brief Struct representing a fan on the O-RU.

--- a/libhalmplane/inc/MplanePerformanceMgmt.h
+++ b/libhalmplane/inc/MplanePerformanceMgmt.h
@@ -286,6 +286,4 @@ typedef void (*halmplane_epe_meas_cb_t)(
 int halmplane_activateEpeMeasObjects(
     struct epe_measurement_objects_t config, halmplane_epe_meas_cb_t cb);
 
-#endif
-
 #endif // __MPLANE_PERFORMANCE_MGMT_H__

--- a/libhalmplane/inc/MplaneSync.h
+++ b/libhalmplane/inc/MplaneSync.h
@@ -45,7 +45,7 @@ typedef struct ptp_config_s {
   uint8_t* accepted_block_classes;
   ptp_profile_t ptp_profile;
   struct {
-    multi_cast_mac_address_t multicast_mac_address;
+    multicast_mac_address_t multicast_mac_address;
     int16_t delay_asymmetry;
   } g_8275_1_config;
   struct {
@@ -125,7 +125,7 @@ typedef struct synce_status_s {
   } sources;
 } synce_status_t;
 
-/** @struct gnass_config_s
+/** @struct gnss_config_s
  *  @brief GNSS Configuration
  */
 typedef struct gnss_config_s {
@@ -141,10 +141,10 @@ typedef struct gnss_state_s {
   char* name;
   enum {
     SYNCHRONIZED,
-    ACQUIRING - SYNC,
-    ANTENNA - DISCONNECTED,
+    ACQUIRING_SYNC,
+    ANTENNA_DISCONNECTED,
     BOOTING,
-    ANTENNA - SHORT - CIRCUIT
+    ANTENNA_SHORT_CIRCUIT
   } gnss_sync_status;
   struct {
     uint8_t satellites_tracked;

--- a/libhalmplane/inc/MplaneTransceiver.h
+++ b/libhalmplane/inc/MplaneTransceiver.h
@@ -7,6 +7,7 @@
 
 #ifndef __MPLANE_TRANSCEIVER_H__
 #define __MPLANE_TRANSCEIVER_H__
+#include <stdint.h>
 
 typedef struct leafref_s {
   char* path;

--- a/libhalmplane/modular/CMakeLists.txt
+++ b/libhalmplane/modular/CMakeLists.txt
@@ -1,0 +1,37 @@
+
+find_library(TINYXML2 tinyxml2)
+find_library(DL dl)
+
+target_link_libraries(halmplane
+  ${DL}
+  ${TINYXML2}
+)
+
+string(CONCAT SRC
+
+  "src/HalMplane.cpp;"
+  "src/ModuleLoader.cpp;"
+  "src/MplaneAlarms.cpp;"
+  "src/MplaneAld.cpp;"
+  "src/MplaneAntennaCalibration.cpp;"
+  "src/MplaneBeamforming.cpp;"
+  "src/MplaneDelayMgmt.cpp;"
+  "src/MplaneEcpri.cpp;"
+  "src/MplaneExternalio.cpp;"
+  "src/MplaneFan.cpp;"
+  "src/MplaneHardware.cpp;"
+  "src/MplaneInterfaces.cpp;"
+  "src/MplaneModuleCapability.cpp;"
+#####  "src/MplanePerformanceMgmt.cpp;"
+  "src/MplaneProcessingElements.cpp;"
+  "src/MplaneSupervision.cpp;"
+  "src/MplaneSync.cpp;"
+  "src/MplaneTransceiver.cpp;"
+  "src/MplaneUplaneConf.cpp;"
+
+)
+include_directories("modular/inc")
+
+list(TRANSFORM SRC PREPEND "modular/")
+target_sources(halmplane PRIVATE ${SRC})
+

--- a/libhalmplane/modular/README.md
+++ b/libhalmplane/modular/README.md
@@ -1,0 +1,45 @@
+# *libhalmplane* `modular` Board
+
+This board will allow selecting the halmplane driver for any other compatible
+board by specifying the filename of its shared library in the server configuration.
+
+## Building
+`mplane_server` must be build with BUILD_BOARD=modular
+
+```
+BUILD_BOARD=modular BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE BUILD_BOARD" bitbake mplane-image-x86
+```
+
+To rebuild with a different builtin board type it may be necessary to rebuild that explicitly
+to invalidate the build hash even though the source files have not changed.
+```
+BUILD_BOARD=example BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE BUILD_BOARD" bitbake -C configure halmplane
+```
+
+To select a module in config file, edit `/usr/share/mplane-server/YangConfig.xml`
+in the `<halmplane-board-modular>` element.
+
+To build a specific module
+```
+BUILD_BOARD=example BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE BUILD_BOARD" bitbake -C configure halmplanemodule
+```
+
+Each module has by default a filename of the form `libhalmplane-mod-<BUILD_BOARD>.so` with symlinks
+generated that reflect the version. This will allow parallel installation of multiple modules without
+packaging conflicts.
+
+The current bitbake recipes do not support automatically installing the resulting module into the
+project `rootfs`, so a command similar to
+```
+cp ./tmp/work/core2-64-poky-linux/halmplanemodule/1.1-r0/image/usr/lib/libhalmplane-mod-example.so.1.1.0 ./tmp/work/mplanex86-poky-linux/mplane-image-x86/1.0-r0/rootfs/usr/lib/
+```
+can achieve the desired outcome manually.
+
+
+## Enabling a board for use as a module
+To operate as a module, the only thing needed is to provide a function with prototype
+```
+void *function_map();
+```
+that is also `extern "C"`. Sample code can be found in `example/src/HalMplane.cpp`
+and a complete list of supported API endpoints can be found in `modular/src/HalMplane.cpp`.

--- a/libhalmplane/modular/inc/ModuleLoader.h
+++ b/libhalmplane/modular/inc/ModuleLoader.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef __MODULE_LOADER_H__
+#define __MODULE_LOADER_H__
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <dlfcn.h>
+
+
+class ModuleLoader
+{
+private:
+  const char* libname;
+  void* dlhandle;
+  std::map<std::string, void*> *registered_functions;
+
+public:
+  ModuleLoader();
+  void open(const char* libname);
+  void* get(const char* ftag);
+};
+
+
+ModuleLoader* _loader();
+
+
+#endif

--- a/libhalmplane/modular/src/HalMplane.cpp
+++ b/libhalmplane/modular/src/HalMplane.cpp
@@ -13,7 +13,7 @@
 
 using namespace tinyxml2;
 
-#if 1
+#if 0
 /* example function table
  * this code not needed here but may be copied to an appropriate place in any libhalmplane/<board>
  * that wants the ability to run as a loadable module for convenient loading into the function map
@@ -55,49 +55,114 @@ typedef struct
   void* ptr;
 } labeled_ptr_t;
 
-labeled_ptr_t api_functions[] = {
-  {"int halmplane_init()", (void*)(int (*)()) halmplane_init},
-  {"int halmplane_config(XMLDocument*)", (void*)(int (*)(XMLDocument*)) halmplane_config},
-  {"int halmplane_exit()", (void*)(int (*)()) halmplane_exit},
-  {"int halmplane_registerOranAlarmCallback(halmplane_oran_alarm_cb_t)", (void*)(int (*)(halmplane_oran_alarm_cb_t)) halmplane_registerOranAlarmCallback},
-  {"halmplane_error_t halmplane_ald_get_counters(halmplane_ald_communication_output_t*)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_output_t*)) halmplane_ald_get_counters},
-  {"halmplane_error_t halmplane_ald_get_status(halmplane_ald_communication_output_t*)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_output_t*)) halmplane_ald_get_status},
-  {"halmplane_error_t halmplane_ald_response(halmplane_ald_communication_input_s*, uint16_t)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) halmplane_ald_response},
-  {"halmplane_error_t halmplane_ald_request(halmplane_ald_communication_input_t*, uint16_t)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_t*, uint16_t)) halmplane_ald_request},
-  {"halmplane_error_t halmplane_ald_set_receive_mode(halmplane_ald_communication_input_s*, uint16_t)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) halmplane_ald_set_receive_mode},
-  {"halmplane_error_t halmplane_start_antenna_calibration(const antenna_calibration_data_t*)", (void*)(halmplane_error_t (*)(const antenna_calibration_data_t*)) halmplane_start_antenna_calibration},
-  {"halmplane_error_t halmplane_apply_beamforming_file(char*)", (void*)(halmplane_error_t (*)(char*)) halmplane_apply_beamforming_file},
-  {"int halmplane_setDUToRUDelayMgmnt(o_ru_delay_management_s*)", (void*)(int (*)(o_ru_delay_management_s*)) halmplane_setDUToRUDelayMgmnt},
-  {"bool halmplane_message5Enabled()", (void*)(bool (*)()) halmplane_message5Enabled},
-  {"halmplane_error_t halmplane_get_io_value(external_io_t*)", (void*)(halmplane_error_t (*)(external_io_t*)) halmplane_get_io_value},
-  {"halmplane_error_t halmplane_set_io_value(output_setting_t*)", (void*)(halmplane_error_t (*)(output_setting_t*)) halmplane_set_io_value},
-  {"halmplane_error_t halmplane_get_fan_name(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_name},
-  {"halmplane_error_t halmplane_get_fan_location(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_location},
-  {"halmplane_error_t halmplane_get_fan_present_and_operating(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_present_and_operating},
-  {"halmplane_error_t halmplane_get_fan_vendor_code(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_vendor_code},
-  {"halmplane_error_t halmplane_get_fan_speed(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_speed},
-  {"halmplane_error_t halmplane_get_fan_target_speed(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_target_speed},
-  {"bool halmplane_get_ietf_hardware(ietf_hardware_t* hw)", (void*)(bool (*)(ietf_hardware_t* hw)) halmplane_get_ietf_hardware},
-  {"int halmplane_registerHwStateChange(halmplane_notificationHwStateChange_cb_t)", (void*)(int (*)(halmplane_notificationHwStateChange_cb_t)) halmplane_registerHwStateChange},
-  {"int halmplane_registerHwStateOper(halmplane_notificationHwStateOper_cb_t)", (void*)(int (*)(halmplane_notificationHwStateOper_cb_t)) halmplane_registerHwStateOper},
-  {"halmplane_error_t halmplane_get_energysaving_state(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_energysaving_state},
-  {"halmplane_error_t halmplane_get_availability_type(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_availability_type},
-  {"halmplane_error_t halmplane_get_label_content(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_label_content},
-  {"halmplane_error_t halmplane_get_product_code(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_product_code},
-  {"halmplane_error_t halmplane_is_energy_saving_enabled(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_is_energy_saving_enabled},
-  {"halmplane_error_t halmplane_get_dying_gasp_support(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_dying_gasp_support},
-  {"halmplane_error_t halmplane_get_last_service_date(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_last_service_date},
-  {"halmplane_error_t halmplane_get_o_ran_name(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_o_ran_name},
-  {"halmplane_error_t halmplane_interface_update(interface_t*)", (void*)(halmplane_error_t (*)(interface_t*)) halmplane_interface_update},
-  {"halmplane_error_t halmplane_interface_update_description(const char*, const char*)", (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_description},
-  {"halmplane_error_t halmplane_interface_update_type(const char*, const char*)", (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_type},
-  {"halmplane_error_t halmplane_interface_update_enabled(const char*, bool)", (void*)(halmplane_error_t (*)(const char*, bool)) halmplane_interface_update_enabled},
-  {"halmplane_error_t halmplane_interface_update_l2_mtu(const char*, int)", (void*)(halmplane_error_t (*)(const char*, int)) halmplane_interface_update_l2_mtu},
-  {"halmplane_error_t halmplane_interface_update_vlan_tagging(const char*, bool)", (void*)(halmplane_error_t (*)(const char*, bool)) halmplane_interface_update_vlan_tagging},
-  {"halmplane_error_t halmplane_interface_update_base_interface(const char*, const char*)", (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_base_interface},
-  {"halmplane_error_t halmplane_interface_update_vlan_id(const char*, int)", (void*)(halmplane_error_t (*)(const char*, int)) halmplane_interface_update_vlan_id},
-  {"halmplane_error_t halmplane_interface_update_mac_address(const char*, const char*)", (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_mac_address},
-  {"int halmplane_setDUToRUModuleCapability(module_capability_t*)", (void*)(int (*)(module_capability_t*)) halmplane_setDUToRUModuleCapability},
+static labeled_ptr_t api_functions[] = {
+  // HalMplane.h
+  {"int halmplane_init()",
+   (void*)(int (*)()) halmplane_init},
+  {"int halmplane_config(XMLDocument*)",
+   (void*)(int (*)(XMLDocument*)) halmplane_config},
+  {"int halmplane_exit()",
+   (void*)(int (*)()) halmplane_exit},
+
+  // MplaneAlarms.h
+  {"int halmplane_registerOranAlarmCallback(halmplane_oran_alarm_cb_t)",
+   (void*)(int (*)(halmplane_oran_alarm_cb_t)) halmplane_registerOranAlarmCallback},
+
+  // MplaneAld.h
+  {"halmplane_error_t halmplane_ald_get_counters(halmplane_ald_communication_output_t*)",
+   (void*)(halmplane_error_t (*)(halmplane_ald_communication_output_t*)) halmplane_ald_get_counters},
+  {"halmplane_error_t halmplane_ald_get_status(halmplane_ald_communication_output_t*)",
+   (void*)(halmplane_error_t (*)(halmplane_ald_communication_output_t*)) halmplane_ald_get_status},
+  {"halmplane_error_t halmplane_ald_response(halmplane_ald_communication_input_s*, uint16_t)",
+   (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) halmplane_ald_response},
+  {"halmplane_error_t halmplane_ald_request(halmplane_ald_communication_input_t*, uint16_t)",
+   (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_t*, uint16_t)) halmplane_ald_request},
+  {"halmplane_error_t halmplane_ald_set_receive_mode(halmplane_ald_communication_input_s*, uint16_t)",
+   (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) halmplane_ald_set_receive_mode},
+
+  // MplaneAntennaCalibration.h
+  {"halmplane_error_t halmplane_start_antenna_calibration(const antenna_calibration_data_t*)",
+   (void*)(halmplane_error_t (*)(const antenna_calibration_data_t*)) halmplane_start_antenna_calibration},
+
+  // MplaneBeamforming.h
+  {"halmplane_error_t halmplane_apply_beamforming_file(char*)",
+   (void*)(halmplane_error_t (*)(char*)) halmplane_apply_beamforming_file},
+
+  // MplaneDelayMgmt.h
+  {"int halmplane_setDUToRUDelayMgmnt(o_ru_delay_management_s*)",
+   (void*)(int (*)(o_ru_delay_management_s*)) halmplane_setDUToRUDelayMgmnt},
+
+  // MplaneEcpri.h
+  {"bool halmplane_message5Enabled()",
+   (void*)(bool (*)()) halmplane_message5Enabled},
+
+  // MplaneExternalio.h
+  {"halmplane_error_t halmplane_get_io_value(external_io_t*)",
+   (void*)(halmplane_error_t (*)(external_io_t*)) halmplane_get_io_value},
+  {"halmplane_error_t halmplane_set_io_value(output_setting_t*)",
+   (void*)(halmplane_error_t (*)(output_setting_t*)) halmplane_set_io_value},
+
+  // MplaneFan.h
+  {"halmplane_error_t halmplane_get_fan_name(fan_state_t*)",
+   (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_name},
+  {"halmplane_error_t halmplane_get_fan_location(fan_state_t*)",
+   (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_location},
+  {"halmplane_error_t halmplane_get_fan_present_and_operating(fan_state_t*)",
+   (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_present_and_operating},
+  {"halmplane_error_t halmplane_get_fan_vendor_code(fan_state_t*)",
+   (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_vendor_code},
+  {"halmplane_error_t halmplane_get_fan_speed(fan_state_t*)",
+   (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_speed},
+  {"halmplane_error_t halmplane_get_fan_target_speed(fan_state_t*)",
+   (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_target_speed},
+
+  // MplaneHardware.h
+  {"bool halmplane_get_ietf_hardware(ietf_hardware_t* hw)",
+   (void*)(bool (*)(ietf_hardware_t* hw)) halmplane_get_ietf_hardware},
+  {"int halmplane_registerHwStateChange(halmplane_notificationHwStateChange_cb_t)",
+   (void*)(int (*)(halmplane_notificationHwStateChange_cb_t)) halmplane_registerHwStateChange},
+  {"int halmplane_registerHwStateOper(halmplane_notificationHwStateOper_cb_t)",
+   (void*)(int (*)(halmplane_notificationHwStateOper_cb_t)) halmplane_registerHwStateOper},
+  {"halmplane_error_t halmplane_get_energysaving_state(hw_component_t*)",
+   (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_energysaving_state},
+  {"halmplane_error_t halmplane_get_availability_type(hw_component_t*)",
+   (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_availability_type},
+  {"halmplane_error_t halmplane_get_label_content(hw_component_t*)",
+   (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_label_content},
+  {"halmplane_error_t halmplane_get_product_code(hw_component_t*)",
+   (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_product_code},
+  {"halmplane_error_t halmplane_is_energy_saving_enabled(hw_component_t*)",
+   (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_is_energy_saving_enabled},
+  {"halmplane_error_t halmplane_get_dying_gasp_support(hw_component_t*)",
+   (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_dying_gasp_support},
+  {"halmplane_error_t halmplane_get_last_service_date(hw_component_t*)",
+   (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_last_service_date},
+  {"halmplane_error_t halmplane_get_o_ran_name(hw_component_t*)",
+   (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_o_ran_name},
+
+  // MplaneInterfaces.h
+  {"halmplane_error_t halmplane_interface_update(interface_t*)",
+   (void*)(halmplane_error_t (*)(interface_t*)) halmplane_interface_update},
+  {"halmplane_error_t halmplane_interface_update_description(const char*, const char*)",
+   (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_description},
+  {"halmplane_error_t halmplane_interface_update_type(const char*, const char*)",
+   (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_type},
+  {"halmplane_error_t halmplane_interface_update_enabled(const char*, bool)",
+   (void*)(halmplane_error_t (*)(const char*, bool)) halmplane_interface_update_enabled},
+  {"halmplane_error_t halmplane_interface_update_l2_mtu(const char*, int)",
+   (void*)(halmplane_error_t (*)(const char*, int)) halmplane_interface_update_l2_mtu},
+  {"halmplane_error_t halmplane_interface_update_vlan_tagging(const char*, bool)",
+   (void*)(halmplane_error_t (*)(const char*, bool)) halmplane_interface_update_vlan_tagging},
+  {"halmplane_error_t halmplane_interface_update_base_interface(const char*, const char*)",
+   (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_base_interface},
+  {"halmplane_error_t halmplane_interface_update_vlan_id(const char*, int)",
+   (void*)(halmplane_error_t (*)(const char*, int)) halmplane_interface_update_vlan_id},
+  {"halmplane_error_t halmplane_interface_update_mac_address(const char*, const char*)",
+   (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_mac_address},
+
+  // MplaneModuleCapability.h
+  {"int halmplane_setDUToRUModuleCapability(module_capability_t*)",
+   (void*)(int (*)(module_capability_t*)) halmplane_setDUToRUModuleCapability},
 
   
   /*
@@ -112,36 +177,73 @@ labeled_ptr_t api_functions[] = {
   //{"int halmplane_activateTxMeasObjects(const struct tx_measurement_objects_t, halmplane_tx_stats_meas_cb_t)", (int (*)(const struct tx_measurement_objects_t, halmplane_tx_stats_meas_cb_t)) halmplane_activateTxMeasObjects},
   //{"int halmplane_activateEpeMeasObjects(struct epe_measurement_objects_t, halmplane_epe_meas_cb_t)", (int (*)(struct epe_measurement_objects_t, halmplane_epe_meas_cb_t)) halmplane_activateEpeMeasObjects},
 
-  
-  {"halmplane_error_t halmplane_update_ru_element(ru_elements_t*)", (void*)(halmplane_error_t (*)(ru_elements_t*)) halmplane_update_ru_element},
-  {"uint32_t halmplane_get_cu_supervison_interval()", (void*)(uint32_t (*)()) halmplane_get_cu_supervison_interval},
-  {"uint32_t halmplane_set_cu_supervison_interval(uint32_t)", (void*)(uint32_t (*)(uint32_t)) halmplane_set_cu_supervison_interval},
-  {"halmplane_error_t halmplane_set_ptp_config(const ptp_config_t)", (void*)(halmplane_error_t (*)(const ptp_config_t)) halmplane_set_ptp_config},
-  {"halmplane_error_t halmplane_get_ptp_status(ptp_status_t*)", (void*)(halmplane_error_t (*)(ptp_status_t*)) halmplane_get_ptp_status},
-  {"halmplane_error_t halmplane_set_synce_config(const synce_config_t)", (void*)(halmplane_error_t (*)(const synce_config_t)) halmplane_set_synce_config},
-  {"halmplane_error_t halmplane_get_synce_status(synce_status_t*)", (void*)(halmplane_error_t (*)(synce_status_t*)) halmplane_get_synce_status},
-  {"halmplane_error_t halmplane_set_gnss_config(const gnss_config_t)", (void*)(halmplane_error_t (*)(const gnss_config_t)) halmplane_set_gnss_config},
-  {"halmplane_error_t halmplane_get_gnss_status(gnss_status_t*)", (void*)(halmplane_error_t (*)(gnss_status_t*)) halmplane_get_gnss_status},
-  {"int halmplane_get_port_transceivers(port_transceivers_t*)", (void*)(int (*)(port_transceivers_t*)) halmplane_get_port_transceivers},
-  {"int halmplane_get_tx_array(const char* name, tx_array_t*)", (void*)(int (*)(const char* name, tx_array_t*)) halmplane_get_tx_array},
-  {"const char** halmplane_get_tx_array_names()", (void*)(const char** (*)()) halmplane_get_tx_array_names},
-  {"int halmplane_get_low_level_tx_endpoint(const char*, low_level_tx_endpoint_t*)", (void*)(int (*)(const char*, low_level_tx_endpoint_t*)) halmplane_get_low_level_tx_endpoint},
-  {"int halmplane_get_low_level_tx_endpoints(low_level_tx_endpoint_t**, int*)", (void*)(int (*)(low_level_tx_endpoint_t**, int*)) halmplane_get_low_level_tx_endpoints},
-  {"int halmplane_get_rx_array(const char*, rx_array_t*)", (void*)(int (*)(const char*, rx_array_t*)) halmplane_get_rx_array},
-  {"const char** halmplane_get_rx_array_names()", (void*)(const char** (*)()) halmplane_get_rx_array_names},
-  {"int halmplane_get_low_level_rx_endpoint(const char*, low_level_rx_endpoint_t*)", (void*)(int (*)(const char*, low_level_rx_endpoint_t*)) halmplane_get_low_level_rx_endpoint},
-  {"int halmplane_get_low_level_rx_endpoints(low_level_rx_endpoint_t**, int*)", (void*)(int (*)(low_level_rx_endpoint_t**, int*)) halmplane_get_low_level_rx_endpoints},
-  {"int halmplane_tx_carrier_state_change(const char*, uint64_t, uint64_t, double, const char*, int)", (void*)(int (*)(const char*, uint64_t, uint64_t, double, const char*, int)) halmplane_tx_carrier_state_change},
-  {"int halmplane_rx_carrier_state_change(const char*, uint64_t, uint64_t, double, const char*, int)",(void*) (int (*)(const char*, uint64_t, uint64_t, double, const char*, int)) halmplane_rx_carrier_state_change},
-  {"int halmplane_setUPlaneConfiguration(user_plane_configuration_t*)", (void*)(int (*)(user_plane_configuration_t*)) halmplane_setUPlaneConfiguration},
-  {"int halmplane_update_rx_eaxc(const char*, e_axcid_t*)", (void*)(int (*)(const char*, e_axcid_t*)) halmplane_update_rx_eaxc},
-  {"int halmplane_update_tx_eaxc(const char*, e_axcid_t*)", (void*)(int (*)(const char*, e_axcid_t*)) halmplane_update_tx_eaxc},
-  {"int halmplane_update_rx_endpoint_compression(const char*, compression_t*)", (void*)(int (*)(const char*, compression_t*)) halmplane_update_rx_endpoint_compression},
-  {"int halmplane_update_tx_endpoint_compression(const char*, compression_t*)",(void*) (int (*)(const char*, compression_t*)) halmplane_update_tx_endpoint_compression},
-  {"int halmplane_update_rx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)", (void*)(int (*)(const char*, dynamic_compression_configuration_t*)) halmplane_update_rx_endpoint_compression_dyn_config},
-  {"int halmplane_update_tx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)",(void*) (int (*)(const char*, dynamic_compression_configuration_t*)) halmplane_update_tx_endpoint_compression_dyn_config},
-  {"int halmplane_register_rx_carrier_state_cb(halmplane_carrier_state_cb_t)", (void*)(int (*)(halmplane_carrier_state_cb_t)) halmplane_register_rx_carrier_state_cb},
-  {"int halmplane_register_tx_carrier_state_cb(halmplane_carrier_state_cb_t)", (void*)(int (*)(halmplane_carrier_state_cb_t)) halmplane_register_tx_carrier_state_cb},
+  // MplaneProcessingElements.h
+  {"halmplane_error_t halmplane_update_ru_element(ru_elements_t*)",
+   (void*)(halmplane_error_t (*)(ru_elements_t*)) halmplane_update_ru_element},
+
+  // MplaneSupervision.h
+  {"uint32_t halmplane_get_cu_supervison_interval()",
+   (void*)(uint32_t (*)()) halmplane_get_cu_supervison_interval},
+  {"uint32_t halmplane_set_cu_supervison_interval(uint32_t)",
+   (void*)(uint32_t (*)(uint32_t)) halmplane_set_cu_supervison_interval},
+
+  // MplaneSync.h
+  {"halmplane_error_t halmplane_set_ptp_config(const ptp_config_t)",
+   (void*)(halmplane_error_t (*)(const ptp_config_t)) halmplane_set_ptp_config},
+  {"halmplane_error_t halmplane_get_ptp_status(ptp_status_t*)",
+   (void*)(halmplane_error_t (*)(ptp_status_t*)) halmplane_get_ptp_status},
+  {"halmplane_error_t halmplane_set_synce_config(const synce_config_t)",
+   (void*)(halmplane_error_t (*)(const synce_config_t)) halmplane_set_synce_config},
+  {"halmplane_error_t halmplane_get_synce_status(synce_status_t*)",
+   (void*)(halmplane_error_t (*)(synce_status_t*)) halmplane_get_synce_status},
+  {"halmplane_error_t halmplane_set_gnss_config(const gnss_config_t)",
+   (void*)(halmplane_error_t (*)(const gnss_config_t)) halmplane_set_gnss_config},
+  {"halmplane_error_t halmplane_get_gnss_status(gnss_status_t*)",
+   (void*)(halmplane_error_t (*)(gnss_status_t*)) halmplane_get_gnss_status},
+
+  // MplaneTransceiver.h
+  {"int halmplane_get_port_transceivers(port_transceivers_t*)",
+   (void*)(int (*)(port_transceivers_t*)) halmplane_get_port_transceivers},
+
+  // MplaneUplaneConf.h
+  {"int halmplane_get_tx_array(const char* name, tx_array_t*)",
+   (void*)(int (*)(const char* name, tx_array_t*)) halmplane_get_tx_array},
+  {"const char** halmplane_get_tx_array_names()",
+   (void*)(const char** (*)()) halmplane_get_tx_array_names},
+  {"int halmplane_get_low_level_tx_endpoint(const char*, low_level_tx_endpoint_t*)",
+   (void*)(int (*)(const char*, low_level_tx_endpoint_t*)) halmplane_get_low_level_tx_endpoint},
+  {"int halmplane_get_low_level_tx_endpoints(low_level_tx_endpoint_t**, int*)",
+   (void*)(int (*)(low_level_tx_endpoint_t**, int*)) halmplane_get_low_level_tx_endpoints},
+  {"int halmplane_get_rx_array(const char*, rx_array_t*)",
+   (void*)(int (*)(const char*, rx_array_t*)) halmplane_get_rx_array},
+  {"const char** halmplane_get_rx_array_names()",
+   (void*)(const char** (*)()) halmplane_get_rx_array_names},
+  {"int halmplane_get_low_level_rx_endpoint(const char*, low_level_rx_endpoint_t*)",
+   (void*)(int (*)(const char*, low_level_rx_endpoint_t*)) halmplane_get_low_level_rx_endpoint},
+  {"int halmplane_get_low_level_rx_endpoints(low_level_rx_endpoint_t**, int*)",
+   (void*)(int (*)(low_level_rx_endpoint_t**, int*)) halmplane_get_low_level_rx_endpoints},
+  {"int halmplane_tx_carrier_state_change(const char*, uint64_t, uint64_t, double, const char*, int)",
+   (void*)(int (*)(const char*, uint64_t, uint64_t, double, const char*, int)) halmplane_tx_carrier_state_change},
+  {"int halmplane_rx_carrier_state_change(const char*, uint64_t, uint64_t, double, const char*, int)",
+   (void*) (int (*)(const char*, uint64_t, uint64_t, double, const char*, int)) halmplane_rx_carrier_state_change},
+  {"int halmplane_setUPlaneConfiguration(user_plane_configuration_t*)",
+   (void*)(int (*)(user_plane_configuration_t*)) halmplane_setUPlaneConfiguration},
+  {"int halmplane_update_rx_eaxc(const char*, e_axcid_t*)",
+   (void*)(int (*)(const char*, e_axcid_t*)) halmplane_update_rx_eaxc},
+  {"int halmplane_update_tx_eaxc(const char*, e_axcid_t*)",
+   (void*)(int (*)(const char*, e_axcid_t*)) halmplane_update_tx_eaxc},
+  {"int halmplane_update_rx_endpoint_compression(const char*, compression_t*)",
+   (void*)(int (*)(const char*, compression_t*)) halmplane_update_rx_endpoint_compression},
+  {"int halmplane_update_tx_endpoint_compression(const char*, compression_t*)",
+   (void*) (int (*)(const char*, compression_t*)) halmplane_update_tx_endpoint_compression},
+  {"int halmplane_update_rx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)",
+   (void*)(int (*)(const char*, dynamic_compression_configuration_t*)) halmplane_update_rx_endpoint_compression_dyn_config},
+  {"int halmplane_update_tx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)",
+   (void*) (int (*)(const char*, dynamic_compression_configuration_t*)) halmplane_update_tx_endpoint_compression_dyn_config},
+  {"int halmplane_register_rx_carrier_state_cb(halmplane_carrier_state_cb_t)",
+   (void*)(int (*)(halmplane_carrier_state_cb_t)) halmplane_register_rx_carrier_state_cb},
+  {"int halmplane_register_tx_carrier_state_cb(halmplane_carrier_state_cb_t)",
+   (void*)(int (*)(halmplane_carrier_state_cb_t)) halmplane_register_tx_carrier_state_cb},
 
   // mark end for easy loop termination
   {NULL, NULL}

--- a/libhalmplane/modular/src/HalMplane.cpp
+++ b/libhalmplane/modular/src/HalMplane.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <iostream>
+#include "libtinyxml2/tinyxml2.h"
+#include "HalMplane.h"
+
+#include "ModuleLoader.h"
+
+using namespace tinyxml2;
+
+#if 1
+/* example function table
+ * this code not needed here but may be copied to an appropriate place in any libhalmplane/<board>
+ * that wants the ability to run as a loadable module for convenient loading into the function map
+ *
+ * in that context, functions not provided by the implementation may be removed from the table
+ *
+ * There should be only one function of each name (no overloading) but name is still mangled
+ * -- explicit casting gets a pointer to the correct function regardless of overloading or mangling
+ *
+ */
+
+#include "HalMplane.h"
+#include "MplaneAlarms.h"
+#include "MplaneAld.h"
+#include "MplaneAntennaCalibration.h"
+#include "MplaneBeamforming.h"
+#include "MplaneCompression.h"
+#include "MplaneDelayMgmt.h"
+#include "MplaneDhcp.h"
+#include "MplaneEcpri.h"
+#include "MplaneExternalio.h"
+#include "MplaneFan.h"
+#include "MplaneFaultMgmt.h"
+#include "MplaneHardware.h"
+#include "MplaneInterfaces.h"
+#include "MplaneModuleCapability.h"
+//#include "MplanePerformanceMgmt.h"
+#include "MplaneProcessingElements.h"
+#include "MplaneSupervision.h"
+#include "MplaneSync.h"
+#include "MplaneTransceiver.h"
+#include "MplaneTypes.h"
+#include "MplaneUplaneConf.h"
+
+
+typedef struct
+{
+  const char* key;
+  void* ptr;
+} labeled_ptr_t;
+
+labeled_ptr_t api_functions[] = {
+  {"int halmplane_init()", (void*)(int (*)()) halmplane_init},
+  {"int halmplane_config(XMLDocument*)", (void*)(int (*)(XMLDocument*)) halmplane_config},
+  {"int halmplane_exit()", (void*)(int (*)()) halmplane_exit},
+  {"int halmplane_registerOranAlarmCallback(halmplane_oran_alarm_cb_t)", (void*)(int (*)(halmplane_oran_alarm_cb_t)) halmplane_registerOranAlarmCallback},
+  {"halmplane_error_t halmplane_ald_get_counters(halmplane_ald_communication_output_t*)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_output_t*)) halmplane_ald_get_counters},
+  {"halmplane_error_t halmplane_ald_get_status(halmplane_ald_communication_output_t*)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_output_t*)) halmplane_ald_get_status},
+  {"halmplane_error_t halmplane_ald_response(halmplane_ald_communication_input_s*, uint16_t)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) halmplane_ald_response},
+  {"halmplane_error_t halmplane_ald_request(halmplane_ald_communication_input_t*, uint16_t)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_t*, uint16_t)) halmplane_ald_request},
+  {"halmplane_error_t halmplane_ald_set_receive_mode(halmplane_ald_communication_input_s*, uint16_t)", (void*)(halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) halmplane_ald_set_receive_mode},
+  {"halmplane_error_t halmplane_start_antenna_calibration(const antenna_calibration_data_t*)", (void*)(halmplane_error_t (*)(const antenna_calibration_data_t*)) halmplane_start_antenna_calibration},
+  {"halmplane_error_t halmplane_apply_beamforming_file(char*)", (void*)(halmplane_error_t (*)(char*)) halmplane_apply_beamforming_file},
+  {"int halmplane_setDUToRUDelayMgmnt(o_ru_delay_management_s*)", (void*)(int (*)(o_ru_delay_management_s*)) halmplane_setDUToRUDelayMgmnt},
+  {"bool halmplane_message5Enabled()", (void*)(bool (*)()) halmplane_message5Enabled},
+  {"halmplane_error_t halmplane_get_io_value(external_io_t*)", (void*)(halmplane_error_t (*)(external_io_t*)) halmplane_get_io_value},
+  {"halmplane_error_t halmplane_set_io_value(output_setting_t*)", (void*)(halmplane_error_t (*)(output_setting_t*)) halmplane_set_io_value},
+  {"halmplane_error_t halmplane_get_fan_name(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_name},
+  {"halmplane_error_t halmplane_get_fan_location(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_location},
+  {"halmplane_error_t halmplane_get_fan_present_and_operating(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_present_and_operating},
+  {"halmplane_error_t halmplane_get_fan_vendor_code(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_vendor_code},
+  {"halmplane_error_t halmplane_get_fan_speed(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_speed},
+  {"halmplane_error_t halmplane_get_fan_target_speed(fan_state_t*)", (void*)(halmplane_error_t (*)(fan_state_t*)) halmplane_get_fan_target_speed},
+  {"bool halmplane_get_ietf_hardware(ietf_hardware_t* hw)", (void*)(bool (*)(ietf_hardware_t* hw)) halmplane_get_ietf_hardware},
+  {"int halmplane_registerHwStateChange(halmplane_notificationHwStateChange_cb_t)", (void*)(int (*)(halmplane_notificationHwStateChange_cb_t)) halmplane_registerHwStateChange},
+  {"int halmplane_registerHwStateOper(halmplane_notificationHwStateOper_cb_t)", (void*)(int (*)(halmplane_notificationHwStateOper_cb_t)) halmplane_registerHwStateOper},
+  {"halmplane_error_t halmplane_get_energysaving_state(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_energysaving_state},
+  {"halmplane_error_t halmplane_get_availability_type(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_availability_type},
+  {"halmplane_error_t halmplane_get_label_content(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_label_content},
+  {"halmplane_error_t halmplane_get_product_code(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_product_code},
+  {"halmplane_error_t halmplane_is_energy_saving_enabled(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_is_energy_saving_enabled},
+  {"halmplane_error_t halmplane_get_dying_gasp_support(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_dying_gasp_support},
+  {"halmplane_error_t halmplane_get_last_service_date(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_last_service_date},
+  {"halmplane_error_t halmplane_get_o_ran_name(hw_component_t*)", (void*)(halmplane_error_t (*)(hw_component_t*)) halmplane_get_o_ran_name},
+  {"halmplane_error_t halmplane_interface_update(interface_t*)", (void*)(halmplane_error_t (*)(interface_t*)) halmplane_interface_update},
+  {"halmplane_error_t halmplane_interface_update_description(const char*, const char*)", (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_description},
+  {"halmplane_error_t halmplane_interface_update_type(const char*, const char*)", (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_type},
+  {"halmplane_error_t halmplane_interface_update_enabled(const char*, bool)", (void*)(halmplane_error_t (*)(const char*, bool)) halmplane_interface_update_enabled},
+  {"halmplane_error_t halmplane_interface_update_l2_mtu(const char*, int)", (void*)(halmplane_error_t (*)(const char*, int)) halmplane_interface_update_l2_mtu},
+  {"halmplane_error_t halmplane_interface_update_vlan_tagging(const char*, bool)", (void*)(halmplane_error_t (*)(const char*, bool)) halmplane_interface_update_vlan_tagging},
+  {"halmplane_error_t halmplane_interface_update_base_interface(const char*, const char*)", (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_base_interface},
+  {"halmplane_error_t halmplane_interface_update_vlan_id(const char*, int)", (void*)(halmplane_error_t (*)(const char*, int)) halmplane_interface_update_vlan_id},
+  {"halmplane_error_t halmplane_interface_update_mac_address(const char*, const char*)", (void*)(halmplane_error_t (*)(const char*, const char*)) halmplane_interface_update_mac_address},
+  {"int halmplane_setDUToRUModuleCapability(module_capability_t*)", (void*)(int (*)(module_capability_t*)) halmplane_setDUToRUModuleCapability},
+
+  
+  /*
+   * MplanePerformanceMgmt.h includes types with no definition
+   */
+  //  {"int halmplane_registerOranPerfMeasCallback(halmplane_oran_perf_meas_cb_t)", (int (*)(halmplane_oran_perf_meas_cb_t)) halmplane_registerOranPerfMeasCallback},
+  //{"const halmplane_oran_perf_meas_cb_t get_perf_meas_cb_ptr()", (const halmplane_oran_perf_meas_cb_t (*)()) get_perf_meas_cb_ptr},
+  //{"int halmplane_getRssi(uint8_t, double*)", (int (*)(uint8_t, double*)) halmplane_getRssi},
+  //{"int halmplane_configPerfMeasurementParams(struct performance_measurement_params_t*)", (int (*)(struct performance_measurement_params_t*)) halmplane_configPerfMeasurementParams},
+  //{"int halmplane_activateTransceiverMeasObjects(struct transceiver_measurement_objects_t, halmplane_transceiver_meas_cb_t)", (int (*)(struct transceiver_measurement_objects_t, halmplane_transceiver_meas_cb_t)) halmplane_activateTransceiverMeasObjects},
+  //{"int halmplane_activateRxWindowMeasObjects(struct rx_window_measurement_objects_t, halmplane_rx_window_meas_cb_t)", (int (struct (*)rx_window_measurement_objects_t, halmplane_rx_window_meas_cb_t)) halmplane_activateRxWindowMeasObjects},
+  //{"int halmplane_activateTxMeasObjects(const struct tx_measurement_objects_t, halmplane_tx_stats_meas_cb_t)", (int (*)(const struct tx_measurement_objects_t, halmplane_tx_stats_meas_cb_t)) halmplane_activateTxMeasObjects},
+  //{"int halmplane_activateEpeMeasObjects(struct epe_measurement_objects_t, halmplane_epe_meas_cb_t)", (int (*)(struct epe_measurement_objects_t, halmplane_epe_meas_cb_t)) halmplane_activateEpeMeasObjects},
+
+  
+  {"halmplane_error_t halmplane_update_ru_element(ru_elements_t*)", (void*)(halmplane_error_t (*)(ru_elements_t*)) halmplane_update_ru_element},
+  {"uint32_t halmplane_get_cu_supervison_interval()", (void*)(uint32_t (*)()) halmplane_get_cu_supervison_interval},
+  {"uint32_t halmplane_set_cu_supervison_interval(uint32_t)", (void*)(uint32_t (*)(uint32_t)) halmplane_set_cu_supervison_interval},
+  {"halmplane_error_t halmplane_set_ptp_config(const ptp_config_t)", (void*)(halmplane_error_t (*)(const ptp_config_t)) halmplane_set_ptp_config},
+  {"halmplane_error_t halmplane_get_ptp_status(ptp_status_t*)", (void*)(halmplane_error_t (*)(ptp_status_t*)) halmplane_get_ptp_status},
+  {"halmplane_error_t halmplane_set_synce_config(const synce_config_t)", (void*)(halmplane_error_t (*)(const synce_config_t)) halmplane_set_synce_config},
+  {"halmplane_error_t halmplane_get_synce_status(synce_status_t*)", (void*)(halmplane_error_t (*)(synce_status_t*)) halmplane_get_synce_status},
+  {"halmplane_error_t halmplane_set_gnss_config(const gnss_config_t)", (void*)(halmplane_error_t (*)(const gnss_config_t)) halmplane_set_gnss_config},
+  {"halmplane_error_t halmplane_get_gnss_status(gnss_status_t*)", (void*)(halmplane_error_t (*)(gnss_status_t*)) halmplane_get_gnss_status},
+  {"int halmplane_get_port_transceivers(port_transceivers_t*)", (void*)(int (*)(port_transceivers_t*)) halmplane_get_port_transceivers},
+  {"int halmplane_get_tx_array(const char* name, tx_array_t*)", (void*)(int (*)(const char* name, tx_array_t*)) halmplane_get_tx_array},
+  {"const char** halmplane_get_tx_array_names()", (void*)(const char** (*)()) halmplane_get_tx_array_names},
+  {"int halmplane_get_low_level_tx_endpoint(const char*, low_level_tx_endpoint_t*)", (void*)(int (*)(const char*, low_level_tx_endpoint_t*)) halmplane_get_low_level_tx_endpoint},
+  {"int halmplane_get_low_level_tx_endpoints(low_level_tx_endpoint_t**, int*)", (void*)(int (*)(low_level_tx_endpoint_t**, int*)) halmplane_get_low_level_tx_endpoints},
+  {"int halmplane_get_rx_array(const char*, rx_array_t*)", (void*)(int (*)(const char*, rx_array_t*)) halmplane_get_rx_array},
+  {"const char** halmplane_get_rx_array_names()", (void*)(const char** (*)()) halmplane_get_rx_array_names},
+  {"int halmplane_get_low_level_rx_endpoint(const char*, low_level_rx_endpoint_t*)", (void*)(int (*)(const char*, low_level_rx_endpoint_t*)) halmplane_get_low_level_rx_endpoint},
+  {"int halmplane_get_low_level_rx_endpoints(low_level_rx_endpoint_t**, int*)", (void*)(int (*)(low_level_rx_endpoint_t**, int*)) halmplane_get_low_level_rx_endpoints},
+  {"int halmplane_tx_carrier_state_change(const char*, uint64_t, uint64_t, double, const char*, int)", (void*)(int (*)(const char*, uint64_t, uint64_t, double, const char*, int)) halmplane_tx_carrier_state_change},
+  {"int halmplane_rx_carrier_state_change(const char*, uint64_t, uint64_t, double, const char*, int)",(void*) (int (*)(const char*, uint64_t, uint64_t, double, const char*, int)) halmplane_rx_carrier_state_change},
+  {"int halmplane_setUPlaneConfiguration(user_plane_configuration_t*)", (void*)(int (*)(user_plane_configuration_t*)) halmplane_setUPlaneConfiguration},
+  {"int halmplane_update_rx_eaxc(const char*, e_axcid_t*)", (void*)(int (*)(const char*, e_axcid_t*)) halmplane_update_rx_eaxc},
+  {"int halmplane_update_tx_eaxc(const char*, e_axcid_t*)", (void*)(int (*)(const char*, e_axcid_t*)) halmplane_update_tx_eaxc},
+  {"int halmplane_update_rx_endpoint_compression(const char*, compression_t*)", (void*)(int (*)(const char*, compression_t*)) halmplane_update_rx_endpoint_compression},
+  {"int halmplane_update_tx_endpoint_compression(const char*, compression_t*)",(void*) (int (*)(const char*, compression_t*)) halmplane_update_tx_endpoint_compression},
+  {"int halmplane_update_rx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)", (void*)(int (*)(const char*, dynamic_compression_configuration_t*)) halmplane_update_rx_endpoint_compression_dyn_config},
+  {"int halmplane_update_tx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)",(void*) (int (*)(const char*, dynamic_compression_configuration_t*)) halmplane_update_tx_endpoint_compression_dyn_config},
+  {"int halmplane_register_rx_carrier_state_cb(halmplane_carrier_state_cb_t)", (void*)(int (*)(halmplane_carrier_state_cb_t)) halmplane_register_rx_carrier_state_cb},
+  {"int halmplane_register_tx_carrier_state_cb(halmplane_carrier_state_cb_t)", (void*)(int (*)(halmplane_carrier_state_cb_t)) halmplane_register_tx_carrier_state_cb},
+
+  // mark end for easy loop termination
+  {NULL, NULL}
+};
+#endif
+
+
+
+/*
+ * any module loaded later will have its halmplane_init() run after YANG config has been loaded
+ */
+int halmplane_init()
+{
+  return 0;
+}
+
+/*
+ * this function will not run correctly if called before halmplane_init()
+ */
+int halmplane_config(XMLDocument* doc)
+{
+  void* fptr;
+  int module_status = 0;
+  const char* libname;
+  
+  XMLElement* module = doc->FirstChildElement("root")->FirstChildElement("hal_module");
+  if (module) 
+    {
+      // Get the file element
+      libname = module->FirstChildElement("file")->Attribute("value");
+      if (!libname) 
+	{
+	  std::cerr << "file value not found!" << std::endl;
+	  return -1;
+	}
+    } 
+  else 
+    {
+      std::cerr <<  "hal_module element not found!" << std::endl;
+      return -1;
+    }
+
+    
+  _loader()->open(libname);
+  fptr = _loader()->get("int halmplane_init()");
+  if(fptr != NULL)
+    {
+      module_status = ((int (*)()) fptr)();
+      if(module_status != 0)
+	{
+	  std::cerr << "module init failed " << module_status << std::endl;
+	  return module_status;
+	}
+    }
+  fptr = _loader()->get("int halmplane_config(XMLDocument* doc)");
+  if(fptr != NULL)
+    {
+      module_status = ((int (*)(XMLDocument)) fptr)(doc);
+      if(module_status != 0)
+	{
+	  std::cerr << "module config failed " << module_status << std::endl;
+	  return module_status;
+	}
+    }
+
+  return 0;
+}
+
+
+int halmplane_exit()
+{
+  int module_status = 0;
+  void* fptr;
+  fptr = _loader()->get("int halmplane_exit()");
+  if(fptr != NULL)
+    {
+      module_status = ((int (*)()) fptr)();
+      if(module_status != 0)
+	{
+	  std::cerr << "module exit failed " << module_status << std::endl;
+	  return module_status;
+	}
+    }
+  return 0;
+}

--- a/libhalmplane/modular/src/ModuleLoader.cpp
+++ b/libhalmplane/modular/src/ModuleLoader.cpp
@@ -13,13 +13,13 @@ ModuleLoader::ModuleLoader()
 {
   libname = "uninitialized";
   dlhandle = NULL;
-  registered_functions = NULL;
+  registered_functions = new std::map<std::string, void*>();
 }
 
 void ModuleLoader::open(const char* libfilename)
 {
   libname = libfilename;
-  dlhandle = dlopen(libname, RTLD_NOW);
+  dlhandle = dlopen(libname, RTLD_NOW|RTLD_DEEPBIND);
 
   if (!dlhandle) 
     {
@@ -28,6 +28,10 @@ void ModuleLoader::open(const char* libfilename)
   void* (*rf)() = reinterpret_cast<void* (*)()>(dlsym(dlhandle, "function_map"));
   if(rf)
     {
+      if(registered_functions)
+	{
+	  delete registered_functions;
+	}
       registered_functions = (std::map<std::string, void*>*) rf();
     }
 

--- a/libhalmplane/modular/src/ModuleLoader.cpp
+++ b/libhalmplane/modular/src/ModuleLoader.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ModuleLoader.h"
+#include <iostream>
+
+
+ModuleLoader::ModuleLoader()
+{
+  libname = "uninitialized";
+  dlhandle = NULL;
+  registered_functions = NULL;
+}
+
+void ModuleLoader::open(const char* libfilename)
+{
+  libname = libfilename;
+  dlhandle = dlopen(libname, RTLD_NOW);
+
+  if (!dlhandle) 
+    {
+      std::cerr << dlerror() << std::endl;
+    }
+  void* (*rf)() = reinterpret_cast<void* (*)()>(dlsym(dlhandle, "function_map"));
+  if(rf)
+    {
+      registered_functions = (std::map<std::string, void*>*) rf();
+    }
+
+  if(!registered_functions)
+    {
+      registered_functions = new std::map<std::string, void*>();
+    }
+}
+
+void* ModuleLoader::get(const char* key)
+{
+  return (*registered_functions)[key];
+}
+
+
+ModuleLoader* _loader()
+{
+  static ModuleLoader* instanceptr = new ModuleLoader();
+  return instanceptr;
+}

--- a/libhalmplane/modular/src/ModuleLoader.cpp
+++ b/libhalmplane/modular/src/ModuleLoader.cpp
@@ -19,7 +19,7 @@ ModuleLoader::ModuleLoader()
 void ModuleLoader::open(const char* libfilename)
 {
   libname = libfilename;
-  dlhandle = dlopen(libname, RTLD_NOW|RTLD_DEEPBIND);
+  dlhandle = dlmopen(LM_ID_NEWLM, libname, RTLD_NOW|RTLD_DEEPBIND);
 
   if (!dlhandle) 
     {

--- a/libhalmplane/modular/src/MplaneAlarms.cpp
+++ b/libhalmplane/modular/src/MplaneAlarms.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstddef>
+#include "MplaneAlarms.h"
+#include "ModuleLoader.h"
+
+int halmplane_registerOranAlarmCallback(halmplane_oran_alarm_cb_t callback)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_registerOranAlarmCallback(halmplane_oran_alarm_cb_t)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(halmplane_oran_alarm_cb_t)) fptr)(callback);
+    }
+
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneAld.cpp
+++ b/libhalmplane/modular/src/MplaneAld.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneAld.h"
+#include "ModuleLoader.h"
+
+
+halmplane_error_t halmplane_ald_get_counters(halmplane_ald_communication_output_t* ald_status)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_ald_get_counters(halmplane_ald_communication_output_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(halmplane_ald_communication_output_t*)) fptr)(ald_status);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_ald_get_status(halmplane_ald_communication_output_t* ald_status)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_ald_get_status(halmplane_ald_communication_output_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(halmplane_ald_communication_output_t*)) fptr)(ald_status);
+    }
+  return status;
+}  
+
+halmplane_error_t halmplane_ald_response(halmplane_ald_communication_input_s* ald_req, uint16_t msg_size)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_ald_response(halmplane_ald_communication_input_s*, uint16_t)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) fptr)(ald_req, msg_size);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_ald_request(halmplane_ald_communication_input_t* ald_req, uint16_t msg_size)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_ald_request(halmplane_ald_communication_input_t*, uint16_t)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) fptr)(ald_req, msg_size);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_ald_set_receive_mode(halmplane_ald_communication_input_s* ald_req, uint16_t msg_size)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_ald_set_receive_mode(halmplane_ald_communication_input_s*, uint16_t)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(halmplane_ald_communication_input_s*, uint16_t)) fptr)(ald_req, msg_size);
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneAntennaCalibration.cpp
+++ b/libhalmplane/modular/src/MplaneAntennaCalibration.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneAntennaCalibration.h"
+#include "ModuleLoader.h"
+
+
+halmplane_error_t halmplane_start_antenna_calibration(const antenna_calibration_data_t* acd)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_start_antenna_calibration(const antenna_calibration_data_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const antenna_calibration_data_t*)) fptr)(acd);
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneBeamforming.cpp
+++ b/libhalmplane/modular/src/MplaneBeamforming.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneBeamforming.h"
+#include "ModuleLoader.h"
+
+
+halmplane_error_t halmplane_apply_beamforming_file(char* filepath)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_apply_beamforming_file(char*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(char*)) fptr)(filepath);
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneDelayMgmt.cpp
+++ b/libhalmplane/modular/src/MplaneDelayMgmt.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneDelayMgmt.h"
+#include "ModuleLoader.h"
+
+int halmplane_setDUToRUDelayMgmnt(o_ru_delay_management_s* ru_delay_mgmt)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_setDUToRUDelayMgmnt(o_ru_delay_management_s*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(o_ru_delay_management_s*)) fptr)(ru_delay_mgmt);
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneEcpri.cpp
+++ b/libhalmplane/modular/src/MplaneEcpri.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneEcpri.h"
+#include "ModuleLoader.h"
+
+
+/**
+ * Check if message5 is enabled on RU.
+ *
+ * Returns true or false.
+ */
+bool halmplane_message5Enabled(void)
+{
+  bool status = 0;
+  void* fptr;
+
+  fptr = _loader()->get("bool halmplane_message5Enabled()");
+  if(fptr == NULL)
+    {
+      status = 0;
+    }
+  else
+    {
+      status = ((bool (*)()) fptr)();
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneExternalio.cpp
+++ b/libhalmplane/modular/src/MplaneExternalio.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneExternalio.h"
+#include "ModuleLoader.h"
+
+
+halmplane_error_t halmplane_get_io_value(external_io_t* io)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_io_value(external_io_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(external_io_t*)) fptr)(io);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_set_io_value(output_setting_t* out_setting)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_set_io_value(output_setting_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(output_setting_t*)) fptr)(out_setting);
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneFan.cpp
+++ b/libhalmplane/modular/src/MplaneFan.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneFan.h"
+#include "ModuleLoader.h"
+
+
+halmplane_error_t halmplane_get_fan_name(fan_state_t* fan_state)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_fan_name(fan_state_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(fan_state_t*)) fptr)(fan_state);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_fan_location(fan_state_t* fan_state)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_fan_location(fan_state_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(fan_state_t*)) fptr)(fan_state);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_fan_present_and_operating(fan_state_t* fan_state)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_fan_present_and_operating(fan_state_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(fan_state_t*)) fptr)(fan_state);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_fan_vendor_code(fan_state_t* fan_state)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_fan_vendor_code(fan_state_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(fan_state_t*)) fptr)(fan_state);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_fan_speed(fan_state_t* fan_state)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_fan_speed(fan_state_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(fan_state_t*)) fptr)(fan_state);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_fan_target_speed(fan_state_t* fan_state)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_fan_target_speed(fan_state_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(fan_state_t*)) fptr)(fan_state);
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneHardware.cpp
+++ b/libhalmplane/modular/src/MplaneHardware.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneHardware.h"
+#include "ModuleLoader.h"
+
+
+bool halmplane_get_ietf_hardware(ietf_hardware_t* hw)
+{
+  bool status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("bool halmplane_get_ietf_hardware(ietf_hardware_t* hw)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((bool (*)(ietf_hardware_t* hw)) fptr)(hw);
+    }
+
+  return status;
+}
+
+int halmplane_registerHwStateChange(halmplane_notificationHwStateChange_cb_t cb)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_registerHwStateChange(halmplane_notificationHwStateChange_cb_t)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(halmplane_notificationHwStateChange_cb_t)) fptr)(cb);
+    }
+
+  return status;
+}
+
+int halmplane_registerHwStateOper(halmplane_notificationHwStateOper_cb_t cb)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_registerHwStateOper(halmplane_notificationHwStateOper_cb_t)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(halmplane_notificationHwStateOper_cb_t)) fptr)(cb);
+    }
+
+  return status;
+}
+
+halmplane_error_t halmplane_get_energysaving_state(hw_component_t* hw_comp)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_energysaving_state(hw_component_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(hw_component_t*)) fptr)(hw_comp);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_availability_type(hw_component_t* hw_comp)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_availability_type(hw_component_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(hw_component_t*)) fptr)(hw_comp);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_label_content(hw_component_t* hw_comp)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_label_content(hw_component_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(hw_component_t*)) fptr)(hw_comp);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_product_code(hw_component_t* hw_comp)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_product_code(hw_component_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(hw_component_t*)) fptr)(hw_comp);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_is_energy_saving_enabled(hw_component_t* hw_comp)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_is_energy_saving_enabled(hw_component_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(hw_component_t*)) fptr)(hw_comp);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_dying_gasp_support(hw_component_t* hw_comp)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_dying_gasp_support(hw_component_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(hw_component_t*)) fptr)(hw_comp);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_last_service_date(hw_component_t* hw_comp)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_last_service_date(hw_component_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(hw_component_t*)) fptr)(hw_comp);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_o_ran_name(hw_component_t* hw_comp)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_o_ran_name(hw_component_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(hw_component_t*)) fptr)(hw_comp);
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneInterfaces.cpp
+++ b/libhalmplane/modular/src/MplaneInterfaces.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+#include "MplaneInterfaces.h"
+#include "ModuleLoader.h"
+
+halmplane_error_t halmplane_interface_update(interface_t* interface)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update(interface_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(interface_t*)) fptr)(interface);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_interface_update_description(const char* name, const char* description)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update_description(const char*, const char*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const char*, const char*)) fptr)(name, description);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_interface_update_type(const char* name, const char* type)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update_type(const char*, const char*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const char*, const char*)) fptr)(name, type);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_interface_update_enabled(const char* name, bool enabled)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update_enabled(const char*, bool)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const char*, bool)) fptr)(name, enabled);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_interface_update_l2_mtu(const char* name, int l2Mtu)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update_l2_mtu(const char*, int)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const char*, int)) fptr)(name, l2Mtu);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_interface_update_vlan_tagging(const char* name, bool vlanTagging)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update_vlan_tagging(const char*, bool)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const char*, bool)) fptr)(name, vlanTagging);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_interface_update_base_interface(const char* name, const char* baseInterface)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update_base_interface(const char*, const char*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const char*, const char*)) fptr)(name, baseInterface);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_interface_update_vlan_id(const char* name, int vlanId)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update_vlan_id(const char*, int)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const char*, int)) fptr)(name, vlanId);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_interface_update_mac_address(const char* name, const char* macAddress)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_interface_update_mac_address(const char*, const char*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const char*, const char*)) fptr)(name, macAddress);
+    }  
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneModuleCapability.cpp
+++ b/libhalmplane/modular/src/MplaneModuleCapability.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneCompression.h"
+#include "MplaneModuleCapability.h"
+#include "ModuleLoader.h"
+
+
+int halmplane_setDUToRUModuleCapability(module_capability_t* mod_capability)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_setDUToRUModuleCapability(module_capability_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(module_capability_t*)) fptr)(mod_capability);
+    }
+
+  return status;
+}

--- a/libhalmplane/modular/src/MplanePerformanceMgmt.cpp
+++ b/libhalmplane/modular/src/MplanePerformanceMgmt.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#if 0
+#include "MplanePerformanceMgmt.h"
+  /*
+   * MplanePerformanceMgmt.h includes types with no definition
+   */
+
+int halmplane_registerOranPerfMeasCallback(
+    halmplane_oran_perf_meas_cb_t callback);
+const halmplane_oran_perf_meas_cb_t get_perf_meas_cb_ptr(void);
+
+// Get Rssi for the specified interface; Valid values: 0 - 3
+// Returns 0 - success or a non zero vlaue for error code
+int halmplane_getRssi(uint8_t interface, double* rssiValue);
+
+int halmplane_configPerfMeasurementParams(
+    struct performance_measurement_params_t* config);
+
+// Configure each measurement object and register call backs for various
+// measurement objects.
+
+// Transceiver measurement objects
+int halmplane_activateTransceiverMeasObjects(
+    struct transceiver_measurement_objects_t config,
+    halmplane_transceiver_meas_cb_t cb);
+
+// Rx Window Measurement Objects
+int halmplane_activateRxWindowMeasObjects(
+    struct rx_window_measurement_objects_t config,
+    halmplane_rx_window_meas_cb_t cb);
+
+// TX Measurement Objects, results are Tx_stats
+int halmplane_activateTxMeasObjects(
+    const struct tx_measurement_objects_t config,
+    halmplane_tx_stats_meas_cb_t cb);
+
+// EPE Measurement Objects
+int halmplane_activateEpeMeasObjects(
+    struct epe_measurement_objects_t config, halmplane_epe_meas_cb_t cb);
+
+#endif

--- a/libhalmplane/modular/src/MplaneProcessingElements.cpp
+++ b/libhalmplane/modular/src/MplaneProcessingElements.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneProcessingElements.h"
+#include "ModuleLoader.h"
+
+halmplane_error_t halmplane_update_ru_element(ru_elements_t* ru_element)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_update_ru_element(ru_elements_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(ru_elements_t*)) fptr)(ru_element);
+    }
+  return status;
+}
+

--- a/libhalmplane/modular/src/MplaneSupervision.cpp
+++ b/libhalmplane/modular/src/MplaneSupervision.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneSupervision.h"
+#include "ModuleLoader.h"
+/**
+ * Get CU monitoring interval
+ *
+ */
+uint32_t halmplane_get_cu_supervison_interval(void)
+{
+  uint32_t interval = 1;
+  void* fptr;
+
+  fptr = _loader()->get("uint32_t halmplane_get_cu_supervison_interval()");
+  if(fptr == NULL)
+    {
+      interval = 1;
+    }
+  else
+    {
+      interval = ((uint32_t (*)()) fptr)();
+    }
+
+  return interval;
+}
+/**
+ * Set CU monitoring interval, return 0 for success OR error code.
+ *
+ */
+
+uint32_t halmplane_set_cu_supervison_interval(uint32_t cu_monitoring_interval)
+{
+  uint32_t interval = 1;
+  void* fptr;
+
+  fptr = _loader()->get("uint32_t halmplane_set_cu_supervison_interval(uint32_t)");
+  if(fptr == NULL)
+    {
+      interval = 1;
+    }
+  else
+    {
+      interval = ((uint32_t (*)(uint32_t)) fptr)(cu_monitoring_interval);
+    }
+
+  return interval;
+}
+

--- a/libhalmplane/modular/src/MplaneSync.cpp
+++ b/libhalmplane/modular/src/MplaneSync.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneSync.h"
+#include "ModuleLoader.h"
+
+
+halmplane_error_t halmplane_set_ptp_config(const ptp_config_t ptp_config)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_set_ptp_config(const ptp_config_t)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const ptp_config_t)) fptr)(ptp_config);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_ptp_status(ptp_status_t* ptp_status)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_ptp_status(ptp_status_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(ptp_status_t*)) fptr)(ptp_status);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_set_synce_config(const synce_config_t synce_config)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_set_synce_config(const synce_config_t)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const synce_config_t)) fptr)(synce_config);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_synce_status(synce_status_t* synce_status)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_synce_status(synce_status_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(synce_status_t*)) fptr)(synce_status);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_set_gnss_config(const gnss_config_t gnss_config)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_set_gnss_config(const gnss_config_t)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(const gnss_config_t)) fptr)(gnss_config);
+    }
+  return status;
+}
+
+halmplane_error_t halmplane_get_gnss_status(gnss_status_t* gnss_status)
+{
+  halmplane_error_t status = UNAVAILABLE;
+  void* fptr;
+
+  fptr = _loader()->get("halmplane_error_t halmplane_get_gnss_status(gnss_status_t*)");
+  if(fptr == NULL)
+    {
+      status = UNIMPLEMENTED;
+    }
+  else
+    {
+      status = ((halmplane_error_t (*)(gnss_status_t*)) fptr)(gnss_status);
+    }
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneTransceiver.cpp
+++ b/libhalmplane/modular/src/MplaneTransceiver.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneTransceiver.h"
+#include "ModuleLoader.h"
+
+/**
+ * Get port transceivers for the specified port_number from HAL
+ * Returns 0 if successfull else error code.
+ */
+int halmplane_get_port_transceivers(port_transceivers_t* transceivers)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_get_port_transceivers(port_transceivers_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(port_transceivers_t*)) fptr)(transceivers);
+    }
+
+  return status;
+}

--- a/libhalmplane/modular/src/MplaneUplaneConf.cpp
+++ b/libhalmplane/modular/src/MplaneUplaneConf.cpp
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) Linux Foundation and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MplaneUplaneConf.h"
+#include "ModuleLoader.h"
+
+
+int halmplane_get_tx_array(const char* name, tx_array_t* tx_array)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_get_tx_array(const char*, tx_array_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, tx_array_t*)) fptr)(name, tx_array);
+    }
+
+  return status;
+}
+
+const char** halmplane_get_tx_array_names()
+{
+  void* fptr;
+  const char** names = NULL;
+  fptr = _loader()->get("const char** halmplane_get_tx_array_names()");
+  if(fptr == NULL)
+    {
+      names = NULL;
+    }
+  else
+    {
+      names = ((const char** (*)()) fptr)();
+    }
+   
+  return names;
+}
+
+int halmplane_get_low_level_tx_endpoint(const char* name, low_level_tx_endpoint_t* tx_endpoint)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_get_low_level_tx_endpoint(const char*, low_level_tx_endpoint_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, low_level_tx_endpoint_t*)) fptr)(name, tx_endpoint);
+    }
+
+  return status;
+}
+
+int halmplane_get_low_level_tx_endpoints(low_level_tx_endpoint_t** tx_endpoints, int* n_endpoints)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_get_low_level_tx_endpoints(low_level_tx_endpoint_t**, int*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(low_level_tx_endpoint_t**, int*)) fptr)(tx_endpoints, n_endpoints);
+    }
+  return status;
+}
+
+int halmplane_get_rx_array(const char* name, rx_array_t* rx_arrays)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_get_rx_array(const char*, rx_array_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, rx_array_t*)) fptr)(name, rx_arrays);
+    }
+  return status;
+}
+
+const char** halmplane_get_rx_array_names()
+{
+  void* fptr;
+  const char** names = NULL;
+  fptr = _loader()->get("const char** halmplane_get_rx_array_names()");
+  if(fptr == NULL)
+    {
+      names = NULL;
+    }
+  else
+    {
+      names = ((const char** (*)()) fptr)();
+    }
+   
+  return names;
+}
+
+int halmplane_get_low_level_rx_endpoint(const char* name, low_level_rx_endpoint_t* rx_endpoint)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_get_low_level_rx_endpoint(const char*, low_level_rx_endpoint_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, low_level_rx_endpoint_t*)) fptr)(name, rx_endpoint);
+    }
+  return status;
+}
+
+int halmplane_get_low_level_rx_endpoints(low_level_rx_endpoint_t** rx_endpoints, int* n_endpoints)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_get_low_level_rx_endpoints(low_level_rx_endpoint_t**, int*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(low_level_rx_endpoint_t**, int*)) fptr)(rx_endpoints, n_endpoints);
+    }
+  return status;
+}
+
+int halmplane_tx_carrier_state_change(const char* name, uint64_t chbw, uint64_t center,
+				      double gain, const char* new_state, int do_apply)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_tx_carrier_state_change(const char*, uint64_t, uint64_t, double, const char*, int)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, uint64_t, uint64_t,
+			 double, const char*, int)) fptr)(name, chbw, center,
+							  gain, new_state, do_apply);
+    }
+  return status;
+}
+
+int halmplane_rx_carrier_state_change(
+    const char* name,
+    uint64_t chbw,
+    uint64_t center,
+    double gain_correction,
+    const char* new_state,
+    int do_apply)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_rx_carrier_state_change(const char*, uint64_t, uint64_t, double, const char*, int)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, uint64_t, uint64_t,
+			 double, const char*, int)) fptr)(name, chbw, center,
+							  gain_correction, new_state, do_apply);
+    }
+  return status;
+}
+
+int halmplane_setUPlaneConfiguration(user_plane_configuration_t* uplane_cfg)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_setUPlaneConfiguration(user_plane_configuration_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(user_plane_configuration_t*)) fptr)(uplane_cfg);
+    }
+  return status;
+}
+
+int halmplane_update_rx_eaxc(const char* endpoint_name, e_axcid_t* eaxc)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_update_rx_eaxc(const char*, e_axcid_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, e_axcid_t*)) fptr)(endpoint_name, eaxc);
+    }
+  return status;
+}
+
+int halmplane_update_tx_eaxc(const char* endpoint_name, e_axcid_t* eaxc)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_update_tx_eaxc(const char*, e_axcid_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, e_axcid_t*)) fptr)(endpoint_name, eaxc);
+    }
+  return status;
+}
+
+int halmplane_update_rx_endpoint_compression(const char* endpoint_name, compression_t* compression)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_update_rx_endpoint_compression(const char*, compression_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, compression_t*)) fptr)(endpoint_name, compression);
+    }
+  return status;
+}
+
+int halmplane_update_tx_endpoint_compression(const char* endpoint_name, compression_t* compression)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_update_tx_endpoint_compression(const char*, compression_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, compression_t*)) fptr)(endpoint_name, compression);
+    }
+  return status;
+}
+
+int halmplane_update_rx_endpoint_compression_dyn_config(const char* endpoint_name, dynamic_compression_configuration_t* config)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_update_rx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, dynamic_compression_configuration_t*)) fptr)(endpoint_name, config);
+    }
+  return status;
+}
+
+int halmplane_update_tx_endpoint_compression_dyn_config(const char* endpoint_name, dynamic_compression_configuration_t* config)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_update_tx_endpoint_compression_dyn_config(const char*, dynamic_compression_configuration_t*)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(const char*, dynamic_compression_configuration_t*)) fptr)(endpoint_name, config);
+    }
+  return status;
+}
+
+int halmplane_register_rx_carrier_state_cb(halmplane_carrier_state_cb_t cb)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_register_rx_carrier_state_cb(halmplane_carrier_state_cb_t)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(halmplane_carrier_state_cb_t)) fptr)(cb);
+    }
+  return status;
+}
+
+int halmplane_register_tx_carrier_state_cb(halmplane_carrier_state_cb_t cb)
+{
+  int status = 1;
+  void* fptr;
+
+  fptr = _loader()->get("int halmplane_register_tx_carrier_state_cb(halmplane_carrier_state_cb_t)");
+  if(fptr == NULL)
+    {
+      status = 1;
+    }
+  else
+    {
+      status = ((int (*)(halmplane_carrier_state_cb_t)) fptr)(cb);
+    }
+  return status;
+}

--- a/meta-mplane/README.md
+++ b/meta-mplane/README.md
@@ -27,6 +27,7 @@ bitbake mplane-image-x86
 ```
 
 #### Prepare the mplane_server environment:
+Make sure you're in the meta-mplane directory.
 ```bash
 # Create a target directory for the root filesystem
 mkdir -p ../../mplane-server/var/volatile/log && cd ../../mplane-server/
@@ -49,11 +50,11 @@ usr/share/mplane-server/scripts/o-ran-user-config.sh
 
 #### Run the mplane_server:
 ```bash
-# Open a new terminal and run the following command to display the server logs
-tail -f var/log/console.log
-
 # Run the mplane_server commands in the chrooted terminal
 mplane-server-app --help
+
+# Open a new terminal and run the following command to display the server logs
+tail -f var/log/console.log
 ```
 
 The terminal window displaying console.log would show the following:

--- a/meta-mplane/recipes-mplane/halmplane/halmplane_0.1.bb
+++ b/meta-mplane/recipes-mplane/halmplane/halmplane_0.1.bb
@@ -18,5 +18,7 @@ BUILD_BOARD ?= "example"
 EXTRA_OECMAKE_append += " -DBUILD_BOARD=${BUILD_BOARD}"
 EXTRA_OECMAKE_append += " -DCONTEXT=YOCTO"
 
+DEPENDS += "libtinyxml2"
+
 PROVIDES += "virtual/halmplane"
 RPROVIDES_${PN} += "virtual/halmplane"

--- a/meta-mplane/recipes-mplane/halmplane/halmplane_0.1.bb
+++ b/meta-mplane/recipes-mplane/halmplane/halmplane_0.1.bb
@@ -14,8 +14,10 @@ inherit cmake
 
 # set this as appropriate
 BUILD_BOARD ?= "example"
+BUILD_BOARD_STYLE ?= "BUILTIN"
 
 EXTRA_OECMAKE_append += " -DBUILD_BOARD=${BUILD_BOARD}"
+EXTRA_OECMAKE_append += " -DBUILD_BOARD_STYLE=${BUILD_BOARD_STYLE}"
 EXTRA_OECMAKE_append += " -DCONTEXT=YOCTO"
 
 DEPENDS += "libtinyxml2"

--- a/meta-mplane/recipes-mplane/halmplane_module/halmplane_module_1.1.bb
+++ b/meta-mplane/recipes-mplane/halmplane_module/halmplane_module_1.1.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Generic M-Plane HAL"
+DESCRIPTION = "Open M-Plane Server"
+SECTION = "base"
+LICENSE = "Meta-MIT"
+LIC_FILES_CHKSUM = "file://${META_MPLANE_DIR}/licenses/Meta-MIT;md5=ae79e563b8a09c8fc37978f18dbaa640"
+
+FILESEXTRAPATHS_append := ":${META_MPLANE_DIR}/.."
+
+SRC_URI = "file://libhalmplane"
+
+S = "${WORKDIR}/libhalmplane"
+
+inherit cmake
+
+# set this as appropriate
+BUILD_BOARD ?= "example"
+CONTEXT ?= "YOCTO"
+
+EXTRA_OECMAKE_append += " -DBUILD_BOARD=${BUILD_BOARD}"
+EXTRA_OECMAKE_append += " -DCONTEXT=${CONTEXT}"
+
+PROVIDES += "halmplane_module"

--- a/meta-mplane/recipes-mplane/halmplanemodule/halmplanemodule_1.1.bb
+++ b/meta-mplane/recipes-mplane/halmplanemodule/halmplanemodule_1.1.bb
@@ -19,4 +19,4 @@ CONTEXT ?= "YOCTO"
 EXTRA_OECMAKE_append += " -DBUILD_BOARD=${BUILD_BOARD}"
 EXTRA_OECMAKE_append += " -DCONTEXT=${CONTEXT}"
 
-PROVIDES += "halmplane_module"
+PROVIDES += "halmplanemodule"

--- a/meta-mplane/recipes-mplane/halmplanemodule/halmplanemodule_1.1.bb
+++ b/meta-mplane/recipes-mplane/halmplanemodule/halmplanemodule_1.1.bb
@@ -14,9 +14,13 @@ inherit cmake
 
 # set this as appropriate
 BUILD_BOARD ?= "example"
+BUILD_BOARD_STYLE ?= "MODULE"
 CONTEXT ?= "YOCTO"
 
 EXTRA_OECMAKE_append += " -DBUILD_BOARD=${BUILD_BOARD}"
+EXTRA_OECMAKE_append += " -DBUILD_BOARD_STYLE=${BUILD_BOARD_STYLE}"
 EXTRA_OECMAKE_append += " -DCONTEXT=${CONTEXT}"
+
+DEPENDS += "libtinyxml2"
 
 PROVIDES += "halmplanemodule"

--- a/mplane_client/example/README.md
+++ b/mplane_client/example/README.md
@@ -25,17 +25,25 @@ there may be a syntax or schema error in the commands file.
 
 When mplane_server is running on the same host:
 ```bash
-# Start the server(mpc_client):
+# Start the server (mpc_client):
 ./wrapper.sh ./mpc_client --insecure
 
-# Separately, run the client(mpclient-demo):
+# Separately, run the client (mpclient-demo):
 ./wrapper.sh ./mpclient-demo \
   --commands ../example/cases/connect.json \
-  --netconfHost 127.0.0.1   --netconfPort 830 \
+  --netconfHost 127.0.0.1 \
+  --netconfPort 830 \
   --netconfUser root \
   --netconfPassword facebook \
-  --insecure 
+  --insecure
 ```
+Using mpclient-demo for the Dockerized build on Linux requires updating the compose file to add the host-gateway 
+for the mplane-client-tester or mplane-client-integrated-tester service, and setting host.docker.internal as netconfHost:
+```
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
 ### Commands File Example
 ```json
 {

--- a/mplane_server/yang-manager-server/services/src/YangServices.cpp
+++ b/mplane_server/yang-manager-server/services/src/YangServices.cpp
@@ -70,7 +70,16 @@ YangServices::YangServices()
   // Register the YANG manager server Service
   registerServiceInsert(YangMgrService::singleton());
 
-  halmplane_init();
+  std::string filePath = cfgData->getPath();
+  tinyxml2::XMLDocument doc;
+  if (doc.LoadFile(filePath.c_str()) == tinyxml2::XML_NO_ERROR)
+    {
+      halmplane_init(&doc);
+    }
+  else
+    {
+      halmplane_init(NULL);
+    }
 
   // YANG
   eventInfo("RRH get YANG manager server");

--- a/mplane_server/yang-manager-server/yang-config/YangConfig.xml
+++ b/mplane_server/yang-manager-server/yang-config/YangConfig.xml
@@ -101,4 +101,7 @@
       <leaf-maximum-number-of-transport-flows value="1" />
     </container-processing-elements>
   </module-o-ran-processing-element>
+  <halmplane-board-modular>
+    <file value="/usr/lib/libhalmplane-mod-example.so.1.1.0" />
+  </halmplane-board-modular>
 </root>


### PR DESCRIPTION
This release provides a major new feature -- a modular implementation of *libhalmplane*.
Previously, the `halmplane` package would always give its shared library the same name,
which means only one version can be installed successfully at a time. This is still the
case, and build defaults have not changed, but there is a new board supported: `modular`.

The `modular` board will attempt to fetch a filename from `YangConfig.xml` and load it
as a module. If successful, each call to a `halmplane` API endpoint will be forwarded to
code loaded from that module. Details on using this system can be found in
`libhalmplane/modular/README.md`.

Benefits of this system include
* it is optional -- system build defaults are not changed, and any board can be built-in
* when developing and testing a new board, switching between iterative build outputs is change a config file and restart `mplane_server`
* board developers who don't yet have an implementation of all API functions don't need to provide any stub functions
* system administrators can install all available modules and choose which to reference in config file
